### PR TITLE
Launch different urls for each page tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,38 +60,13 @@
         <div class="header">
             <h1>Bar Operations</h1>
             <div class="tabs">
-                <a class="tab-btn" data-target="employeeFrame" href="#" title="Employee CRM">Employee CRM</a>
-                <a class="tab-btn" data-target="shiftFrame" href="#" title="Shift Tracker">Shift Tracker</a>
+                <a class="tab-btn" href="employee.html" title="Employee CRM">Employee CRM</a>
+                <a class="tab-btn" href="shift.html" title="Shift Tracker">Shift Tracker</a>
             </div>
         </div>
-        <div class="content">
-            <iframe id="employeeFrame" src="?view=employee" title="Employee CRM"></iframe>
-            <iframe id="shiftFrame" src="?view=shift" title="Shift Tracker"></iframe>
-        </div>
+        
     </div>
 
-    <script>
-        (function() {
-            function selectTab(targetId) {
-                document.querySelectorAll('iframe').forEach(f => f.classList.remove('active'));
-                document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-                var frame = document.getElementById(targetId);
-                var btn = document.querySelector('.tab-btn[data-target="' + targetId + '"]');
-                if (frame) frame.classList.add('active');
-                if (btn) btn.classList.add('active');
-            }
-
-            var params = new URLSearchParams(window.location.search);
-            var view = params.get('view');
-            var initial = view === 'shift' ? 'shiftFrame' : 'employeeFrame';
-            selectTab(initial);
-            document.querySelectorAll('.tab-btn').forEach(btn => {
-                btn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    selectTab(this.dataset.target);
-                });
-            });
-        })();
-    </script>
+    
 </body>
 </html>


### PR DESCRIPTION
Reworked tabs in `index.html` to navigate directly to `employee.html` and `shift.html`.

The previous iframe-based tab switching mechanism was removed to simplify navigation and allow each tab to launch a distinct URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b955e52-96b2-484f-831b-fa772d7fe3b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b955e52-96b2-484f-831b-fa772d7fe3b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

