### PR TITLE
Fix undefined openAddModal function

### DIFF
--- a/shift.html
+++ b/shift.html
@@ -845,6 +845,16 @@
         let currentUser = null;
         let pageUrls = null;
 
+        // Debug logging function - must be defined before use
+        function debugLog(message) {
+            const timestamp = new Date().toISOString();
+            console.log('[SHIFT-DEBUG] 🔍 ' + timestamp + ': ' + message);
+            const debugContent = document.getElementById('debugContent');
+            if (debugContent) {
+                debugContent.innerHTML += '<div>' + new Date().toLocaleTimeString() + ': ' + message + '</div>';
+            }
+        }
+
         // Initialize the app
         document.addEventListener('DOMContentLoaded', function() {
             console.log('🚀 [SHIFT-INIT] ===============================');
@@ -877,15 +887,6 @@
             setupKeyboardNavigation();
             setupLocationAutocomplete();
         });
-
-        function debugLog(message) {
-            const timestamp = new Date().toISOString();
-            console.log('[SHIFT-DEBUG] 🔍 ' + timestamp + ': ' + message);
-            const debugContent = document.getElementById('debugContent');
-            if (debugContent) {
-                debugContent.innerHTML += '<div>' + new Date().toLocaleTimeString() + ': ' + message + '</div>';
-            }
-        }
 
         function showError(message) {
             const container = document.getElementById('errorContainer');


### PR DESCRIPTION
Move `debugLog` function definition to prevent `ReferenceError` and ensure all script functions are defined.

The `debugLog` function was being called during script initialization before its definition. This caused a `ReferenceError` that halted script execution, preventing other functions (like `openAddModal`) from being defined and accessible. Moving `debugLog` to the top of the script resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-29239481-f825-4c8e-9803-2691f6451ec5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29239481-f825-4c8e-9803-2691f6451ec5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

